### PR TITLE
Remove "./" from benchmark path if present

### DIFF
--- a/quick-check.sh
+++ b/quick-check.sh
@@ -14,6 +14,8 @@ function print_error()
   echo "::error file=$BENCHMARK::$*"
 }
 
+BENCHMARK=$(echo $BENCHMARK | sed 's/^\.\///')
+
 echo "::group::Checking \"$BENCHMARK\""
 
 info "File" "$BENCHMARK"


### PR DESCRIPTION
This makes it slightly easier to run the script locally, since it is no longer an error to call `quick-check.sh ./incremental/...`.